### PR TITLE
添加reddit.com的短域名

### DIFF
--- a/surfboard_rules
+++ b/surfboard_rules
@@ -194,6 +194,7 @@ DOMAIN-SUFFIX,pornhub.com,rixCloud,force-remote-dns
 DOMAIN-SUFFIX,quora.com,rixCloud,force-remote-dns
 DOMAIN-SUFFIX,reddit.com,rixCloud,force-remote-dns
 DOMAIN-SUFFIX,redditmedia.com,rixCloud,force-remote-dns
+DOMAIN-SUFFIX,redd.it,rixCloud,force-remote-dns
 DOMAIN-SUFFIX,reuters.com,rixCloud,force-remote-dns
 DOMAIN-SUFFIX,scribd.com,rixCloud,force-remote-dns
 DOMAIN-SUFFIX,shadowsocks.org,rixCloud,force-remote-dns


### PR DESCRIPTION
由于此域名是被dns污染，所以需要`force-remote-dns`参数才可以访问。